### PR TITLE
config example: move to config.example.yml and document gh_token

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.yaml
 *.yml
+!*example.yml
 tokens.txt
 valid_tokens.txt
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -1,0 +1,6 @@
+gh_username:
+gh_password:
+# if you have 2 Factor Authentication enabled on your GitHub account,
+# get a token from https://github.com/settings/tokens
+# and the bot will use that instead of a username and password
+gh_token:

--- a/config.yml.example
+++ b/config.yml.example
@@ -1,2 +1,0 @@
-gh_username:
-gh_password:


### PR DESCRIPTION
- changing it to .yml is for the syntax highlighting
- also document what the gh_token is about
- to add the config.example.yml, .gitignore had to be modified